### PR TITLE
Make tests runnable from project root with pytest -v

### DIFF
--- a/auto_martiniM3/tests/test_basic.py
+++ b/auto_martiniM3/tests/test_basic.py
@@ -4,12 +4,13 @@ Basic sanity test for the auto_martini package.
 import filecmp
 import os
 from pathlib import Path
-from rdkit import Chem
+
 import pytest
+from rdkit import Chem
 
 import auto_martiniM3
 
-dpath = Path("tests/files")
+dpath = Path(__file__).resolve().parent / "files"
 
 
 def test_auto_martini_imported():


### PR DESCRIPTION
Currently the README suggests running:

`pytest -v tests`

This only works if you first `cd` into the `auto_martiniM3` folder, since tests/ lives there. If you run from the project root, pytest fails to find tests/.

Using the updated dpath, one could run pytest from project root via `pytest -v`.

I think this makes instructions easier to follow.